### PR TITLE
Ensure that test actually fails when things are broken

### DIFF
--- a/.github/workflows/update-and-publish.yml
+++ b/.github/workflows/update-and-publish.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       version:
-        description: npm version to publish
+        description: client version to update to and publish
         type: string
         required: true
     secrets:
@@ -19,10 +19,14 @@ on:
     inputs:
       npmTag:
         description: npm tag to publish to
-        type: string
+        type: choice
+        options:
+          - latest
+          - dev
+          - integration
         required: true
       version:
-        description: npm version to publish
+        description: client version to update to and publish
         type: string
         required: true
 
@@ -93,7 +97,9 @@ jobs:
         run: yarn npm publish --tag "$NPM_TAG"
 
       - name: Push
-        run: git push origin main
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: git push origin "$GITHUB_REF"
 
   notify-on-failure:
     name: Notify on publish failure

--- a/example/e2e/starter.test.js
+++ b/example/e2e/starter.test.js
@@ -9,6 +9,6 @@ describe('Example', () => {
   });
 
   it('Show basic test passed indicator', async () => {
-    await expect(element(by.id('test_indicator'))).toBeVisible();
+    await expect(element(by.id('test_indicator_success'))).toBeVisible();
   });
 });

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -80,12 +80,12 @@ export default function App() {
           {e2eSuccess ? (
             <View
               className="rounded-full h-3 w-3 bg-green-500"
-              testID="test_indicator"
+              testID="test_indicator_success"
             />
           ) : (
             <View
               className="rounded-full h-3 w-3 bg-red-500"
-              testID="test_indicator"
+              testID="test_indicator_failure"
             />
           )}
         </View>

--- a/example/src/db.ts
+++ b/example/src/db.ts
@@ -8,6 +8,7 @@ import Chance from 'chance';
 const chance = new Chance();
 
 const basePrisma = new PrismaClient({
+  datasourceUrl: 'file:./my-custom.db',
   log: [{ emit: 'event', level: 'query' }],
 });
 


### PR DESCRIPTION
Test could never actually fail, because the only thing it doess is
checks that `test_indicator` element exists and that element was shown
regardless of test result. Fixed that by giving different test ids to
success and failure indicators.

At the moment, tests deliberately fail because custom databases are not
supported.
