### PR TITLE
Chore: Readme changes to reflect newer prisma react native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Prisma engine adaptation for React Native. Please note that this is a [Preview
 ## Installation
 
 ```
-npm i --save --save-exact @prisma/client@5.14.0-dev.67 @prisma/react-native@5.14.0-dev.67 react-native-quick-base64
+npm i --save --save-exact @prisma/client@latest @prisma/react-native@latest react-native-quick-base64
 npx expo prebuild --clean
 ```
 
@@ -76,7 +76,7 @@ model User {
 you can now generate the Prisma Client like this:
 
 ```
-npx prisma@5.14.0-dev.67 generate
+npx prisma@latest generate
 ```
 
 ## Reactive queries

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Prisma engine adaptation for React Native. Please note that this is a [Preview
 ## Installation
 
 ```
-npm i --save --save-exact @prisma/client@5.14.0-dev.26 @prisma/react-native@5.14.0-dev.26 react-native-quick-base64
+npm i --save --save-exact @prisma/client@5.14.0-dev.67 @prisma/react-native@5.14.0-dev.67 react-native-quick-base64
 npx expo prebuild --clean
 ```
 
@@ -76,7 +76,7 @@ model User {
 you can now generate the Prisma Client like this:
 
 ```
-npx prisma@5.14.0-dev.26 generate
+npx prisma@5.14.0-dev.67 generate
 ```
 
 ## Reactive queries


### PR DESCRIPTION
Update [the instructions here](https://www.npmjs.com/package/@prisma/react-native) to use version 5.14.0-dev.67 by EOD Wednesday so participants at App.js Conf will have the correct instructions.

[Slack thread](https://prisma-company.slack.com/archives/C069WPUMZJM/p1716234984932809)