### PR TITLE
Fix readme misspelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default function App {
 }
 ```
 
-Bare in mind, for the reactive queries to work you have to use the extended client to modify the data:
+Bear in mind, for the reactive queries to work you have to use the extended client to modify the data:
 
 ```ts
 extendedClient.user.create({ ...userData });


### PR DESCRIPTION
Bare in mind is a misspelling of Bear in mind.

https://www.scribbr.com/frequently-asked-questions/bare-in-mind-mean/