### PR TITLE
fix(expo/ios): use dynamic lookup to find path to migration script

### DIFF
--- a/plugin/src/withPrismaIOS.ts
+++ b/plugin/src/withPrismaIOS.ts
@@ -26,13 +26,10 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase): void {
 }
 
 export function addPrismMigrationScriptCopy(script: string): string {
-  return (
-    script +
-    `
-    
-    PRISMA_MIGRATIONS="../node_modules/@prisma/react-native/copy-migrations.sh"
-    chmod a+x ../node_modules/@prisma/react-native/copy-migrations.sh
-
-    /bin/sh -c "$PRISMA_MIGRATIONS"`
-  );
+  return [
+    script,
+    `PRISMA_MIGRATIONS=\`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@prisma/react-native/package.json')) + '/copy-migrations.sh'"\``,
+    'chmod a+x "$PRISMA_MIGRATIONS"',
+    '/bin/sh -c "$PRISMA_MIGRATIONS"',
+  ].join('\n');
 }


### PR DESCRIPTION
Changed the `PRISMA_MIGRATIONS` variable to use the Node binary set by Expo for looking up where 
`@prisma/react-native` is installed. This allows using `@prisma/react-native` in a monorepo where 
the `node_modules/` folder may be hoisted to the top level of the workspace.

The commit also cleans up extraneous leading whitespace from the commands added by the Expo config
plugin.