### PR TITLE
Check for updates less frequently

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,7 +1,7 @@
 name: Check for a new client version
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Every 5 minutes is excessive, we can easily live "every half an hour" schedule for automated updates.
For cases where we need to speed up the things, manually dispatching workflow is always possible.