### PR TITLE
Use prisma/migrations path for migrations script

### DIFF
--- a/copy-migrations.sh
+++ b/copy-migrations.sh
@@ -6,6 +6,6 @@ MIGRATIONS_TARGET=${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 rm -rf "$MIGRATIONS_TARGET/migrations"
 mkdir "$MIGRATIONS_TARGET/migrations"
-cp -r ${SRCROOT}/../migrations ${MIGRATIONS_TARGET}
+cp -r ${SRCROOT}/../prisma/migrations ${MIGRATIONS_TARGET}
 
 echo "migration files copied ✅"


### PR DESCRIPTION
Fixes #34 

The prisma command generates the migration files in the `prisma/migrations` path not `migrations`