### PR TITLE
fix(e2e): update the simulated device from iPhone 14 to 15

### DIFF
--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -27,7 +27,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14',
+        type: 'iPhone 15',
       },
     },
     emulator: {


### PR DESCRIPTION
iPhone 14 is not present in the currently used SDK version, but iPhone 15 is.

Fixes: https://github.com/prisma/team-orm/issues/1417